### PR TITLE
Add vision and problem statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Vision & Problem Statement
+
+## Vision
+
+Build a platform-agnostic REST API that accepts messages from diverse systems, leverages OpenAI's Agent framework to interpret intent and decide actions, and returns actionable outputs. This service acts as a central "brain" for heterogeneous applications, applying AI to reason about failures, notifications, or other events and deliver tailored responses.
+
+### Key Principles
+- **Platform independence**: Request payloads support a generic message body plus optional metadata describing source and context.
+- **Extensible processing**: The OpenAI Agent framework orchestrates tools and models so new message types and actions can be added with minimal code.
+- **Best practices**: Modular architecture, testability, observability, security, and thorough documentation guide implementation.
+
+## Problem Statement
+
+Organizations rely on many services that produce notifications and logs, yet these messages are siloed and require manual interpretation. Developers, for example, often sift through CI pipeline logs to diagnose failures and notify stakeholders. This manual process is slow and error-prone.
+
+We need a single endpoint capable of receiving arbitrary messages (e.g., failed GitLab CI pipelines) and using AI to analyze, decide, and summarize appropriate follow-up actions. The system must accommodate new message sources without redesign, letting teams integrate once and rely on AI-driven decision-making for many scenarios.
+
+### Success Metrics
+- Able to ingest messages from multiple sources with minimal customization.
+- Generates accurate, actionable AI summaries and decisions.
+- New message types are integrated quickly through configuration and tool plug-ins.


### PR DESCRIPTION
## Summary
- establish project vision and problem statement for AI-driven message processing API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa21aab438832db4c4f8c587256951