### PR TITLE
feat: add message model and endpoint

### DIFF
--- a/src/gene/api.py
+++ b/src/gene/api.py
@@ -2,6 +2,8 @@
 
 from fastapi import FastAPI
 
+from .models import Message
+
 app = FastAPI()
 
 __all__ = ["app"]
@@ -14,3 +16,14 @@ async def health() -> dict[str, str]:
     Returns a simple status dictionary indicating the API is running.
     """
     return {"status": "ok"}
+
+
+@app.post("/messages")
+async def create_message(message: Message) -> dict[str, str]:
+    """Accept a message and echo its body.
+
+    Validates the request payload using :class:`Message`. This endpoint is a
+    placeholder for future AI-driven processing and can be extended with
+    routing logic or tool integrations.
+    """
+    return {"body": message.body}

--- a/src/gene/models.py
+++ b/src/gene/models.py
@@ -1,0 +1,29 @@
+"""Data models for the gene API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Message(BaseModel):
+    """Generic message payload.
+
+    This model provides the core fields shared by all messages processed by
+    the API. It can be extended or subclassed to support additional
+    message types as the system grows.
+    """
+
+    body: str = Field(
+        ..., description="Main textual content of the message to interpret."
+    )
+    metadata: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Optional dictionary with context about the message, such as "
+            "environment details or source identifiers. This allows external "
+            "integrations to supply information that may influence processing "
+            "logic."
+        ),
+    )


### PR DESCRIPTION
## Summary
- define `Message` model with body text and optional metadata
- add `/messages` endpoint that validates requests with `Message`

## Testing
- `python -m black src/gene/models.py src/gene/api.py`
- `python -m ruff check src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa33e8315c832d98c9158c7b31c6de