### PR TITLE
feat: add configuration and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,18 @@ We need a single endpoint capable of receiving arbitrary messages (e.g., failed 
 - Able to ingest messages from multiple sources with minimal customization.
 - Generates accurate, actionable AI summaries and decisions.
 - New message types are integrated quickly through configuration and tool plug-ins.
+
+## Configuration
+
+The application reads settings from environment variables or a `.env` file in
+the project root. Available options include:
+
+- `LOG_LEVEL` – controls verbosity of log output. Defaults to `INFO`.
+
+Example `.env` file:
+
+```
+LOG_LEVEL=DEBUG
+```
+
+Settings are loaded at startup by `src/gene/config.py`.

--- a/src/gene/__main__.py
+++ b/src/gene/__main__.py
@@ -3,11 +3,17 @@
 import uvicorn
 
 from .api import app
+from .config import settings
 
 
 def main() -> None:
     """Run the Uvicorn server hosting the API."""
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=8000,
+        log_level=settings.log_level.lower(),
+    )
 
 
 if __name__ == "__main__":

--- a/src/gene/api.py
+++ b/src/gene/api.py
@@ -1,12 +1,29 @@
 """FastAPI application for the gene project."""
 
-from fastapi import FastAPI
+from __future__ import annotations
 
+import logging
+
+from fastapi import FastAPI, Request
+
+from .config import settings
 from .models import Message
+
+logger = logging.getLogger(__name__)
+logger.setLevel(settings.log_level)
 
 app = FastAPI()
 
 __all__ = ["app"]
+
+
+@app.middleware("http")
+async def log_requests(request: Request, call_next):
+    """Log basic information about incoming requests and outgoing responses."""
+    logger.info("Request %s %s", request.method, request.url.path)
+    response = await call_next(request)
+    logger.info("Response %s %s", response.status_code, request.url.path)
+    return response
 
 
 @app.get("/health")

--- a/src/gene/config.py
+++ b/src/gene/config.py
@@ -1,0 +1,39 @@
+"""Application configuration loaded from environment variables or a .env file."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = ["Settings", "settings"]
+
+
+def load_env_file(path: Path) -> None:
+    """Load key-value pairs from ``path`` into ``os.environ`` if present."""
+    if not path.exists():
+        return
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        os.environ.setdefault(key.strip(), value.strip())
+
+
+# Load environment variables from a .env file in the project root.
+load_env_file(Path(__file__).resolve().parents[2] / ".env")
+
+
+@dataclass
+class Settings:
+    """Application settings."""
+
+    log_level: str = os.getenv("LOG_LEVEL", "INFO")
+
+
+settings = Settings()
+
+# Configure root logging according to the resolved settings.
+logging.basicConfig(level=settings.log_level)


### PR DESCRIPTION
## Summary
- load settings from environment variables or `.env`
- log incoming requests and responses
- document configuration options

## Testing
- `ruff .`
- `black --check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa36fdfa80832d9460fd68c3d6715f