### PR TITLE
Add API and model tests with pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,7 @@ target-version = "py311"
 [tool.black]
 line-length = 88
 target-version = ["py311"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=gene --cov-report=term-missing"
+testpaths = ["tests"]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from fastapi.testclient import TestClient
+from gene.api import app
+
+
+def test_health_endpoint_returns_ok():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from gene.models import Message
+
+
+def test_message_requires_body():
+    with pytest.raises(ValidationError):
+        Message()
+
+
+def test_message_accepts_metadata_dict():
+    msg = Message(body="hello", metadata={"source": "unit"})
+    assert msg.metadata == {"source": "unit"}
+
+
+def test_message_rejects_non_dict_metadata():
+    with pytest.raises(ValidationError):
+        Message(body="hi", metadata="invalid")


### PR DESCRIPTION
## Summary
- add tests for `/health` endpoint
- cover `Message` model validation cases
- configure pytest options and coverage in `pyproject.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aa38055404832db37f1fdc1e572e1e