### PR TITLE
Route messages through tools and add reverse example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,16 @@ OPENAI_MODEL=gpt-4o-mini
 ```
 
 Settings are loaded at startup by `src/gene/config.py`.
+
+## Tools
+
+`gene` includes a lightweight tool framework that dispatches messages to
+specialized handlers based on simple prefixes. The following tools are
+available out of the box:
+
+- `echo` – returns the text following the `echo ` prefix.
+- `reverse` – reverses the text following the `reverse ` prefix.
+
+Any message sent to the `/messages` endpoint that matches a tool prefix will be
+handled by that tool and the response will include metadata indicating which
+tool produced the reply.

--- a/src/gene/tools/reverse.py
+++ b/src/gene/tools/reverse.py
@@ -1,0 +1,15 @@
+"""Tool that reverses text after the ``reverse`` prefix."""
+
+from .base import BaseTool
+
+
+class ReverseTool(BaseTool):
+    """Reverse the text that follows ``reverse ``."""
+
+    name = "reverse"
+
+    def can_handle(self, query: str) -> bool:
+        return query.startswith("reverse ")
+
+    def handle(self, query: str) -> str:
+        return query[len("reverse ") :][::-1]

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -31,3 +31,14 @@ def test_messages_endpoint_uses_injected_client():
     data = resp.json()
     assert data["reply"] == "echo: hello"
     set_client(None)
+
+
+def test_messages_endpoint_uses_tool_when_available():
+    set_client(DummyClient())
+    client = TestClient(app)
+    resp = client.post("/messages", json={"body": "reverse abc"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["reply"] == "cba"
+    assert data["metadata"] == {"tool": "reverse"}
+    set_client(None)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,3 +11,9 @@ def test_echo_tool_discovery_and_handling():
     assert tool is not None
     assert tool.handle("echo world") == "world"
     assert handle("echo hi") == "hi"
+
+
+def test_reverse_tool_discovery_and_handling():
+    tool = get_tool("reverse abc")
+    assert tool is not None
+    assert tool.handle("reverse abc") == "cba"


### PR DESCRIPTION
## Summary
- dispatch incoming messages to registered tools before using OpenAI
- add a reverse text tool and document built-in tool prefixes
- cover tool routing and reverse tool with tests

## Testing
- `ruff check .`
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aa5c342f20832d9232fc46aa7550f2